### PR TITLE
disable any local .babelrc to avoid errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
        exclude: /node_modules/,
        loader: 'babel-loader',
        query: {
+         babelrc: false,
          presets: ['react', 'es2015'] 
        }
      }


### PR DESCRIPTION
My local development had a local .babelrc in the $HOME directory which would cause the app to fail to run.  Overriding babelrc fixes the problem.