### PR TITLE
remove empty string from extensions array

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,6 @@ module.exports = {
    ]
  },
  resolve: {
-   extensions: ['', '.js', '.es6']
+   extensions: ['.js', '.es6']
  }
 }


### PR DESCRIPTION
webpack will no longer compile the code with a blank string in the extensions array. removing it allows the project to compile as intended.